### PR TITLE
Remove GitHub Actions badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@
   <a href="https://github.com/rylsherdamz-rgb/stellar-forge/releases">
     <img src="https://img.shields.io/github/v/tag/rylsherdamz-rgb/stellar-forge?label=release&color=7B3FE4">
   </a>
-  <a href="https://github.com/rylsherdamz-rgb/stellar-forge/actions">
-    <img src="https://img.shields.io/github/actions/workflow/status/rylsherdamz-rgb/stellar-forge/publish-npm.yml?branch=master&label=cd&logo=npm&color=blue">
-  </a>
+
   <a href="https://www.npmjs.com/package/create-stellar-agentic">
     <img src="https://img.shields.io/npm/dw/create-stellar-agentic?color=blue&logo=npm&label=downloads%2Fweek">
   </a>


### PR DESCRIPTION
Removed GitHub Actions badge from README.

## Description

Describe the change and which issue it fixes. Include motivation and context.

Closes # (issue)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Eval or agent update

## Components Affected

- [ ] CLAUDE.md (kernel)
- [ ] SKILL.md (orchestration)
- [ ] Agent: `agents/*.md`
- [ ] Eval: `evals/*.md`
- [ ] Template: `templates/*`
- [ ] Skill: `skills/*/SKILL.md`
- [ ] CLI: `packages/create-stellar-agentic/*`
- [ ] MCP: `.mcp.json`
- [ ] Docs: `README.md`, `references/*`

## Verification

- [ ] `npm run validate` passes
- [ ] All relevant evals pass
- [ ] SKILL.md frontmatter is valid (name, version, description, tags)
- [ ] No hardcoded secrets
- [ ] Backward compatible (unless breaking)

## How Has This Been Tested?

Describe the tests you ran.

## Screenshots (if applicable)

## Additional Context
